### PR TITLE
update libs to latest version

### DIFF
--- a/libs/mosquitto/src/messages_mosq.c
+++ b/libs/mosquitto/src/messages_mosq.c
@@ -192,10 +192,10 @@ void _mosquitto_messages_reconnect_reset(struct mosquitto *mosq)
 		mosq->out_queue_len++;
 		message->timestamp = 0;
 
-		if(message->msg.qos > 0){
-			mosq->inflight_messages++;
-		}
 		if(mosq->max_inflight_messages == 0 || mosq->inflight_messages < mosq->max_inflight_messages){
+			if(message->msg.qos > 0){
+				mosq->inflight_messages++;
+			}
 			if(message->msg.qos == 1){
 				message->state = mosq_ms_wait_for_puback;
 			}else if(message->msg.qos == 2){

--- a/libs/mosquitto/src/mosquitto.c
+++ b/libs/mosquitto/src/mosquitto.c
@@ -407,6 +407,15 @@ static int _mosquitto_connect_init(struct mosquitto *mosq, const char *host, int
 
 	mosq->keepalive = keepalive;
 
+	if(mosq->sockpairR != INVALID_SOCKET){
+		COMPAT_CLOSE(mosq->sockpairR);
+		mosq->sockpairR = INVALID_SOCKET;
+	}
+	if(mosq->sockpairW != INVALID_SOCKET){
+		COMPAT_CLOSE(mosq->sockpairW);
+		mosq->sockpairW = INVALID_SOCKET;
+	}
+
 	if(_mosquitto_socketpair(&mosq->sockpairR, &mosq->sockpairW)){
 		_mosquitto_log_printf(mosq, MOSQ_LOG_WARNING,
 				"Warning: Unable to open socket pair, outgoing publish commands may be delayed.");
@@ -854,7 +863,6 @@ int mosquitto_loop(struct mosquitto *mosq, int timeout, int max_packets)
 		if(mosq->ssl){
 			if(mosq->want_write){
 				FD_SET(mosq->sock, &writefds);
-				mosq->want_write = false;
 			}else if(mosq->want_connect){
 				/* Remove possible FD_SET from above, we don't want to check
 				 * for writing if we are still connecting, unless want_write is

--- a/libs/mosquitto/src/mosquitto.h
+++ b/libs/mosquitto/src/mosquitto.h
@@ -45,7 +45,7 @@ extern "C" {
 
 #define LIBMOSQUITTO_MAJOR 1
 #define LIBMOSQUITTO_MINOR 4
-#define LIBMOSQUITTO_REVISION 4
+#define LIBMOSQUITTO_REVISION 8
 /* LIBMOSQUITTO_VERSION_NUMBER looks like 1002001 for e.g. version 1.2.1. */
 #define LIBMOSQUITTO_VERSION_NUMBER (LIBMOSQUITTO_MAJOR*1000000+LIBMOSQUITTO_MINOR*1000+LIBMOSQUITTO_REVISION)
 
@@ -576,6 +576,7 @@ libmosq_EXPORT int mosquitto_disconnect(struct mosquitto *mosq);
  *               Note that although the MQTT protocol doesn't use message ids
  *               for messages with QoS=0, libmosquitto assigns them message ids
  *               so they can be tracked with this parameter.
+ *  topic -      null terminated string of the topic to publish to.
  * 	payloadlen - the size of the payload (bytes). Valid values are between 0 and
  *               268,435,455.
  * 	payload -    pointer to the data to send. If payloadlen > 0 this must be a

--- a/libs/mosquitto/src/mosquitto_internal.h
+++ b/libs/mosquitto/src/mosquitto_internal.h
@@ -207,8 +207,12 @@ struct mosquitto {
 	int sub_count;
 	int pollfd_index;
 #  ifdef WITH_WEBSOCKETS
+#    if defined(LWS_LIBRARY_VERSION_NUMBER)
+	struct lws *wsi;
+#    else
 	struct libwebsocket_context *ws_context;
 	struct libwebsocket *wsi;
+#    endif
 #  endif
 #else
 #  ifdef WITH_SOCKS

--- a/libs/mosquitto/src/net_mosq.c
+++ b/libs/mosquitto/src/net_mosq.c
@@ -712,6 +712,7 @@ ssize_t _mosquitto_net_write(struct mosquitto *mosq, void *buf, size_t count)
 	errno = 0;
 #ifdef WITH_TLS
 	if(mosq->ssl){
+		mosq->want_write = false;
 		ret = SSL_write(mosq->ssl, buf, count);
 		if(ret < 0){
 			err = SSL_get_error(mosq->ssl, ret);
@@ -1125,10 +1126,6 @@ int _mosquitto_socketpair(mosq_sock_t *pairR, mosq_sock_t *pairW)
 			continue;
 		}
 
-		if(_mosquitto_socket_nonblock(listensock)){
-			continue;
-		}
-
 		if(family[i] == AF_INET){
 			sa->sin_family = family[i];
 			sa->sin_addr.s_addr = htonl(INADDR_LOOPBACK);
@@ -1145,6 +1142,7 @@ int _mosquitto_socketpair(mosq_sock_t *pairR, mosq_sock_t *pairW)
 			continue;
 		}
 		if(_mosquitto_socket_nonblock(spR)){
+			COMPAT_CLOSE(spR);
 			COMPAT_CLOSE(listensock);
 			continue;
 		}
@@ -1172,6 +1170,7 @@ int _mosquitto_socketpair(mosq_sock_t *pairR, mosq_sock_t *pairW)
 
 		if(_mosquitto_socket_nonblock(spW)){
 			COMPAT_CLOSE(spR);
+			COMPAT_CLOSE(spW);
 			COMPAT_CLOSE(listensock);
 			continue;
 		}


### PR DESCRIPTION
Updating the libs takes care of a problem where the `client.update` was throwing errors all the time in loop when the connection to the broker got lost.  