### PR TITLE
add mechanism to re-loop when messages are received in update()

### DIFF
--- a/src/ofxMQTT.cpp
+++ b/src/ofxMQTT.cpp
@@ -109,7 +109,9 @@ void ofxMQTT::unsubscribe(string topic) {
 }
 
 void ofxMQTT::update() {
-  int rc1 = mosquitto_loop(mosq, 0, 1);
+  received_messages = 0;
+
+  int rc1 = mosquitto_loop(mosq, 0, 100);
   if (rc1 != MOSQ_ERR_SUCCESS) {
     ofLogError("ofxMQTT") << "Loop error: " << mosquitto_strerror(rc1);
 
@@ -118,6 +120,8 @@ void ofxMQTT::update() {
       ofLogError("ofxMQTT") << "Reconnect error: " << mosquitto_strerror(rc2);
     }
   }
+  if (received_messages>0) update();
+
 }
 
 bool ofxMQTT::connected() { return alive; }
@@ -147,4 +151,5 @@ void ofxMQTT::_on_message(const struct mosquitto_message *message) {
   msg.payload = payload;
 
   ofNotifyEvent(onMessage, msg, this);
+  received_messages++;
 }

--- a/src/ofxMQTT.cpp
+++ b/src/ofxMQTT.cpp
@@ -149,6 +149,8 @@ void ofxMQTT::_on_message(const struct mosquitto_message *message) {
   ofxMQTTMessage msg; 
   msg.topic = message->topic;
   msg.payload = payload;
+  msg.retain = message->retain;
+  msg.qos = message->qos;
 
   ofNotifyEvent(onMessage, msg, this);
   received_messages++;

--- a/src/ofxMQTT.h
+++ b/src/ofxMQTT.h
@@ -10,6 +10,7 @@ class ofxMQTT {
  private:
   struct mosquitto *mosq;
   bool alive = false;
+  size_t received_messages {0};
 
   string hostname;
   int port;

--- a/src/ofxMQTT.h
+++ b/src/ofxMQTT.h
@@ -4,6 +4,8 @@
 struct ofxMQTTMessage {
   string topic;
   string payload;
+  bool retain;
+  int qos;
 };
 
 class ofxMQTT {


### PR DESCRIPTION
when topics are streaming faster than the OF `update()` rate, a backlog accumulates (only a single message is processed per `update()`). this adds a check to re-execute `mosquitto_loop` until no new messages are processed.